### PR TITLE
Ignore underscore names

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -66,6 +66,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			}
 
 			for _, n := range p.Names {
+				if n.Name == "_" {
+					continue
+				}
+
 				if allowErrorInDefer {
 					if ident, ok := p.Type.(*ast.Ident); ok {
 						if ident.Name == "error" && findDeferWithErrorAssignment(funcBody, n.Name) {

--- a/testdata/src/allow-error-in-defer/allow_error_in_defer.go
+++ b/testdata/src/allow-error-in-defer/allow_error_in_defer.go
@@ -15,13 +15,12 @@ func twoReturnParams() (i int, err error) { // want `named return "i" with type 
 	return
 }
 
-// TODO: enable test after https://github.com/firefart/nonamedreturns/pull/7
-//func allUnderscoresExceptError() (_ int, err error) {
-//	defer func() {
-//		err = nil
-//	}()
-//	return
-//}
+func allUnderscoresExceptError() (_ int, err error) {
+	defer func() {
+		err = nil
+	}()
+	return
+}
 
 func customName() (myName error) {
 	defer func() {
@@ -70,10 +69,8 @@ func customType() (err myError) { // want `named return "err" with type "myError
 	return
 }
 
-// TODO: replace `i` with `_` after https://github.com/firefart/nonamedreturns/pull/7
-func notTheLast() (err error, i int) { // want `named return "i" with type "int" found`
+func notTheLast() (err error, _ int) {
 	defer func() {
-		i = 0
 		err = nil
 	}()
 	return

--- a/testdata/src/default-config/default_config.go
+++ b/testdata/src/default-config/default_config.go
@@ -23,6 +23,10 @@ var e = func() (err error) { // want `named return "err" with type "error" found
 	return
 }
 
+var e2 = func() (_ error) {
+	return
+}
+
 func deferWithError() (err error) { // want `named return "err" with type "error" found`
 	defer func() {
 		err = nil // use flag to allow this
@@ -43,6 +47,10 @@ var (
 		err = nil
 		return
 	}
+
+	h2 = func() (_ error) {
+		return
+	}
 )
 
 // this should not match as the implementation does not need named parameters (see below)
@@ -56,8 +64,21 @@ func funcDefintionImpl2(arg1, arg2 interface{}) (num int, err error) { // want `
 	return 0, nil
 }
 
+func funcDefintionImpl3(arg1, arg2 interface{}) (num int, _ error) { // want `named return "num" with type "int" found`
+	return 0, nil
+}
+
+func funcDefintionImpl4(arg1, arg2 interface{}) (_ int, _ error) {
+	return 0, nil
+}
+
 var funcVar = func() (msg string) { // want `named return "msg" with type "string" found`
 	msg = "c"
+	return msg
+}
+
+var funcVar2 = func() (_ string) {
+	msg := "c"
 	return msg
 }
 
@@ -98,3 +119,5 @@ func myLog(format string, args ...interface{}) {
 type obj struct{}
 
 func (o *obj) func1() (err error) { return nil } // want `named return "err" with type "error" found`
+
+func (o *obj) func2() (_ error) { return nil }


### PR DESCRIPTION
Name `_` is the same as no name and should be ignored.

Fixes #6