### PR TITLE
add flag report-error-fun-len

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,3 +6,5 @@ Tutorial on how to write your own linter:
 https://disaev.me/p/writing-useful-go-analysis-linter/
 
 Named errors used in defers are not reported. If you also want to report them set `report-error-in-defer` to true.
+
+For tune off linter for short functions set `report-error-fun-len` as needed


### PR DESCRIPTION
Add flag report-error-fun-len for using naked return for short functions. [tour](https://go.dev/tour/basics/7).
It's not change default linter`s work