### PR TITLE
fix: panic with functions without body

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -53,6 +53,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return
 		}
 
+		// Function without body, ex: https://github.com/golang/go/blob/master/src/internal/syscall/unix/net.go
+		if funcBody == nil {
+			return
+		}
+
 		// no return values
 		if funcResults == nil {
 			return


### PR DESCRIPTION
In rare cases, functions don't have a body.

https://github.com/golang/go/blob/master/src/internal/syscall/unix/net.go


```
ERRO [runner] Panic: nonamedreturns: package "unix" (isInitialPkg: true, needAnalyzeSource: true): runtime error: invalid memory address or nil pointer dereference: goroutine 11202 [running]:
runtime/debug.Stack()
/usr/lib/go/src/runtime/debug/stack.go:24 +0x5e
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_action.go:108 +0x277
panic({0x17ee9c0?, 0x2527420?})
/usr/lib/go/src/runtime/panic.go:770 +0x132
go/ast.Walk({0x1c47440?, 0xc008187ef0?}, {0x1c4cdd0, 0x0})
/usr/lib/go/src/go/ast/walk.go:234 +0x677
go/ast.Inspect(...)
/usr/lib/go/src/go/ast/walk.go:397
github.com/firefart/nonamedreturns/analyzer.findDeferWithVariableAssignment(0x0, 0xc007925320, {0x1c65160, 0xc00797f9e0})
/home/ldez/sources/go/pkg/mod/github.com/firefart/nonamedreturns@v1.0.4/analyzer/analyzer.go:91 +0xb8
github.com/firefart/nonamedreturns/analyzer.run.func1({0x1c4bee8, 0xc007957f50})
/home/ldez/sources/go/pkg/mod/github.com/firefart/nonamedreturns@v1.0.4/analyzer/analyzer.go:76 +0x2eb
golang.org/x/tools/go/ast/inspector.(*Inspector).Preorder(0xc006f79398, {0xc002fcac90?, 0x25568a0?, 0xc0000412c0?}, 0xc00140dcb0)
/home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.20.0/go/ast/inspector/inspector.go:82 +0x8f
github.com/firefart/nonamedreturns/analyzer.run(0xc00110bd40)
/home/ldez/sources/go/pkg/mod/github.com/firefart/nonamedreturns@v1.0.4/analyzer/analyzer.go:41 +0x185
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0xc0027d17a0)
/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_action.go:190 +0xa02
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_action.go:112 +0x17
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc0031dab90, {0x19dfc59, 0xe}, 0xc002fcaf48)
/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0xc0018bc780?)
/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_action.go:111 +0x7a
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0xc0027d17a0)
/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:80 +0xa8
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 698
/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:75 +0x205
WARN [runner] Can't run linter goanalysis_metalinter: goanalysis_metalinter: nonamedreturns: package "unix" (isInitialPkg: true, needAnalyzeSource: true): runtime error: invalid memory address or nil pointer dereference
```