### PR TITLE
feat: add allow-unused-named-returns flag (#17)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,7 +64,7 @@ golangci-lint run ./...
 
 ## Settings
 
-The linter has a single setting.
+The linter has the following settings.
 
 ### `report-error-in-defer`
 
@@ -119,6 +119,73 @@ linters:
     nonamedreturns:
       # report named error if it is assigned inside defer
       report-error-in-defer: true
+```
+
+### `allow-unused-named-returns`
+
+|                       |                                |
+| --------------------- | ------------------------------ |
+| **Type**              | `bool`                         |
+| **Default**           | `false`                        |
+| **Standalone flag**   | `-allow-unused-named-returns`  |
+| **golangci-lint key** | `allow-unused-named-returns`   |
+
+Named returns are useful as documentation in a signature (for example
+`func add(a, b int) (sum int)` tells the reader what the result means). The risk
+comes from *using* them in the body. Set `allow-unused-named-returns` to `true`
+to keep that documentation value while forbidding any reliance on the named
+return: the name is allowed in the signature but reported when **either**
+
+1. it is referenced anywhere in the body (read or assigned), including inside a
+   `defer`, or
+2. the function contains a naked `return` (which implicitly populates every
+   named return).
+
+> A naked `return` inside a nested closure populates that closure's own results, not the enclosing function's, so it does not trigger a report for the enclosing function.
+
+When this setting is `true` it fully takes over: the default error-in-defer
+exemption and the `report-error-in-defer` setting have no effect.
+
+#### Example that is allowed
+
+```go
+// documented but never used in the body, returned explicitly
+func add(a, b int) (sum int) {
+	return a + b
+}
+```
+
+#### Examples that are reported
+
+```go
+// "sum" is referenced in the body
+func add(a, b int) (sum int) {
+	sum = a + b
+	return
+}
+
+// naked return implicitly uses "sum"
+func add(a, b int) (sum int) {
+	return
+}
+```
+
+#### Standalone
+
+```sh
+nonamedreturns -allow-unused-named-returns=true ./...
+```
+
+#### golangci-lint
+
+```yaml
+linters:
+  enable:
+    - nonamedreturns
+  settings:
+    nonamedreturns:
+      # allow named returns for documentation, but report them if used in the body
+      allow-unused-named-returns: true
 ```
 
 ## Why are named returns error prone?

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -11,7 +11,10 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-const FlagReportErrorInDefer = "report-error-in-defer"
+const (
+	FlagReportErrorInDefer      = "report-error-in-defer"
+	FlagAllowUnusedNamedReturns = "allow-unused-named-returns"
+)
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "nonamedreturns",
@@ -24,11 +27,13 @@ var Analyzer = &analysis.Analyzer{
 func flags() flag.FlagSet {
 	fs := flag.FlagSet{}
 	fs.Bool(FlagReportErrorInDefer, false, "report named error if it is assigned inside defer")
+	fs.Bool(FlagAllowUnusedNamedReturns, false, "allow named returns in the signature but report them if referenced in the body or used by a naked return")
 	return fs
 }
 
 func run(pass *analysis.Pass) (any, error) {
 	reportErrorInDefer := pass.Analyzer.Flags.Lookup(FlagReportErrorInDefer).Value.String() == "true"
+	allowUnusedNamedReturns := pass.Analyzer.Flags.Lookup(FlagAllowUnusedNamedReturns).Value.String() == "true"
 	errorType := types.Universe.Lookup("error").Type()
 
 	inspector, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
@@ -66,6 +71,39 @@ func run(pass *analysis.Pass) (any, error) {
 		if funcResults == nil {
 			return
 		}
+
+		if allowUnusedNamedReturns {
+			var referenced map[types.Object]bool
+			var hasNakedReturn bool
+			usageComputed := false
+
+			for _, p := range funcResults.List {
+				if len(p.Names) == 0 {
+					continue
+				}
+
+				for _, n := range p.Names {
+					if n.Name == "_" {
+						continue
+					}
+
+					if !usageComputed {
+						referenced, hasNakedReturn = collectNamedReturnUsage(funcBody, pass.TypesInfo)
+						usageComputed = true
+					}
+
+					obj := pass.TypesInfo.ObjectOf(n)
+					if referenced[obj] || hasNakedReturn {
+						pass.Reportf(n.Pos(), "named return %q with type %q must not be referenced or used by a naked return", n.Name, types.ExprString(p.Type))
+					}
+				}
+			}
+
+			return
+		}
+
+		// existing behavior: report every named return (subject to the
+		// error-in-defer exemption)
 
 		// deferUsed and assigned are computed lazily and at most once per
 		// function: the relatively expensive body walk only happens when there
@@ -148,4 +186,47 @@ func collectDeferUsageAndAssignments(body *ast.BlockStmt, info *types.Info) (map
 	})
 
 	return deferUsed, assigned
+}
+
+// collectNamedReturnUsage walks body a single time and returns:
+//   - referenced:     objects referenced (read or written) anywhere in the body,
+//     including inside nested closures (which may capture the outer named return)
+//   - hasNakedReturn: true if the body contains a return statement with no result
+//     expressions at the top level of the function (naked returns inside nested
+//     closures are excluded because they populate the closure's own results, not
+//     the enclosing function's named returns)
+//
+// Shadowing is handled naturally: a shadowed declaration introduces a distinct
+// types.Object, so it does not match the outer named return.
+func collectNamedReturnUsage(body *ast.BlockStmt, info *types.Info) (map[types.Object]bool, bool) {
+	referenced := make(map[types.Object]bool)
+	hasNakedReturn := false
+
+	var walk func(node ast.Node, inClosure bool)
+	walk = func(node ast.Node, inClosure bool) {
+		ast.Inspect(node, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.Ident:
+				if obj := info.ObjectOf(x); obj != nil {
+					referenced[obj] = true
+				}
+			case *ast.ReturnStmt:
+				// a naked return inside a closure populates the closure's
+				// own results, not the enclosing function's named returns
+				if !inClosure && len(x.Results) == 0 {
+					hasNakedReturn = true
+				}
+			case *ast.FuncLit:
+				// keep collecting referenced identifiers (closures can
+				// capture the outer named return), but everything inside
+				// the closure is in-closure for naked-return purposes
+				walk(x.Body, true)
+				return false
+			}
+			return true
+		})
+	}
+	walk(body, false)
+
+	return referenced, hasNakedReturn
 }

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -22,4 +22,12 @@ func TestAll(t *testing.T) {
 		t.Fatalf("Failed to set flag: %s", err)
 	}
 	analysistest.Run(t, testdata, Analyzer, "report-error-in-defer")
+
+	if err := Analyzer.Flags.Set(FlagReportErrorInDefer, "false"); err != nil {
+		t.Fatalf("Failed to reset flag: %s", err)
+	}
+	if err := Analyzer.Flags.Set(FlagAllowUnusedNamedReturns, "true"); err != nil {
+		t.Fatalf("Failed to set flag: %s", err)
+	}
+	analysistest.Run(t, testdata, Analyzer, "allow-unused-named-returns")
 }

--- a/testdata/src/allow-unused-named-returns/allow_unused_named_returns.go
+++ b/testdata/src/allow-unused-named-returns/allow_unused_named_returns.go
@@ -1,0 +1,102 @@
+package main
+
+import "errors"
+
+// allowed: pure documentation, explicit return, no reference
+func explicitReturn(a, b int) (sum int) {
+	return a + b
+}
+
+// reported: "sum" is assigned in the body
+func assigned(a, b int) (sum int) { // want `named return "sum" with type "int" must not be referenced or used by a naked return`
+	sum = a + b
+	return sum
+}
+
+// reported: "sum" is read in the body
+func read() (sum int) { // want `named return "sum" with type "int" must not be referenced or used by a naked return`
+	if sum > 0 {
+		return 1
+	}
+	return 0
+}
+
+// reported: address of "sum" is taken
+func addressOf() (sum int) { // want `named return "sum" with type "int" must not be referenced or used by a naked return`
+	p := &sum
+	_ = p
+	return 0
+}
+
+// reported: naked return implicitly uses "sum"
+func nakedReturn() (sum int) { // want `named return "sum" with type "int" must not be referenced or used by a naked return`
+	return
+}
+
+// reported: naked return implicitly uses every named result
+func nakedReturnMulti() (a int, b string) { // want `named return "a" with type "int" must not be referenced or used by a naked return` `named return "b" with type "string" must not be referenced or used by a naked return`
+	return
+}
+
+// reported: referenced inside a defer (no exemption in this mode)
+func referencedInDefer() (err error) { // want `named return "err" with type "error" must not be referenced or used by a naked return`
+	defer func() {
+		err = nil
+	}()
+	return errors.New("x")
+}
+
+// allowed: "_" result name is skipped, explicit return
+func underscoreResult() (_ int) {
+	return 1
+}
+
+// allowed: func literal, explicit return, no reference
+var goodLiteral = func() (sum int) {
+	return 1
+}
+
+// reported: func literal with naked return
+var badLiteral = func() (sum int) { // want `named return "sum" with type "int" must not be referenced or used by a naked return`
+	return
+}
+
+type t struct{}
+
+// allowed: method, explicit return, no reference
+func (t) goodMethod() (sum int) {
+	return 1
+}
+
+// reported: method referencing its named result
+func (t) badMethod() (sum int) { // want `named return "sum" with type "int" must not be referenced or used by a naked return`
+	sum = 1
+	return sum
+}
+
+// mixed: only the referenced result is reported; the other uses explicit return
+func mixed() (a int, b int) { // want `named return "a" with type "int" must not be referenced or used by a naked return`
+	a = 1
+	return a, 2
+}
+
+// reported: shared-type result group (single field, two names); only the
+// referenced name is reported, both share the printed type.
+func sharedGroup() (a, b int) { // want `named return "a" with type "int" must not be referenced or used by a naked return`
+	a = 1
+	return a, 2
+}
+
+// reported: "sum" is captured/referenced inside a non-defer closure
+func referencedInClosure() (sum int) { // want `named return "sum" with type "int" must not be referenced or used by a naked return`
+	g := func() int { return sum }
+	return g()
+}
+
+// allowed: the naked return belongs to the nested closure, not to "sum".
+// "sum" is never referenced and the outer function returns explicitly.
+func nakedReturnInNestedClosure() (sum int) {
+	f := func() { return }
+	f()
+	return 1
+}


### PR DESCRIPTION
Add an opt-in `allow-unused-named-returns` boolean flag (default false, existing behavior unchanged). When enabled, named returns are permitted in a signature for documentation but reported once at the declaration if the named return is referenced anywhere in the body (read or write, including captures inside a defer or other closure) or if the function body contains a naked `return`. A naked return inside a nested closure populates that closure's own results, so it does not trigger a report for the enclosing function. When enabled the flag fully takes over: the default error-in-defer exemption and the report-error-in-defer setting have no effect.

Includes analysistest fixtures for the new mode and a Readme section.